### PR TITLE
Add basic CLI with init command

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,3 +7,8 @@ edition = "2024"
 serde = { version = "1", features = ["derive"] }
 sha2 = "0.10"
 bincode = "1"
+clap = { version = "4.0", features = ["derive"] }
+
+[[bin]]
+name = "hit"
+path = "src/main.rs"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,2 +1,3 @@
 pub mod object;
 pub mod storage;
+pub mod repo;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,0 +1,25 @@
+use clap::{Parser, Subcommand};
+
+#[derive(Parser)]
+#[command(name = "hit")]
+#[command(about = "A Git alternative with AI features", long_about = None)]
+struct Cli {
+    #[command(subcommand)]
+    command: Commands,
+}
+
+#[derive(Subcommand)]
+enum Commands {
+    Init,
+}
+
+fn main() {
+    let cli = Cli::parse();
+    match cli.command {
+        Commands::Init => {
+            if let Err(e) = hit_with_gpt::repo::init() {
+                eprintln!("Error initializing repository: {}", e);
+            }
+        }
+    }
+}

--- a/src/repo.rs
+++ b/src/repo.rs
@@ -1,0 +1,39 @@
+use std::fs::{self, File};
+use std::io::Write;
+use std::path::PathBuf;
+
+/// Initialize a new hit repository in the current directory.
+///
+/// Creates the `.hit` directory along with required subdirectories and files.
+/// Reinitializing an existing repository does not error.
+pub fn init() -> std::io::Result<PathBuf> {
+    let cwd = std::env::current_dir()?;
+    let hit_dir = cwd.join(".hit");
+
+    if hit_dir.exists() {
+        println!("Reinitialized existing hit repository in {}", hit_dir.display());
+    } else {
+        println!("Initialized empty hit repository in {}", hit_dir.display());
+    }
+
+    fs::create_dir_all(hit_dir.join("objects"))?;
+    fs::create_dir_all(hit_dir.join("refs").join("heads"))?;
+
+    let config_path = hit_dir.join("config");
+    if !config_path.exists() {
+        File::create(&config_path)?;
+    }
+
+    let head_path = hit_dir.join("HEAD");
+    if !head_path.exists() {
+        let mut head = File::create(&head_path)?;
+        head.write_all(b"refs/heads/main")?;
+    }
+
+    let main_ref = hit_dir.join("refs").join("heads").join("main");
+    if !main_ref.exists() {
+        File::create(&main_ref)?;
+    }
+
+    Ok(hit_dir)
+}

--- a/tests/init.rs
+++ b/tests/init.rs
@@ -1,0 +1,26 @@
+use std::fs;
+
+use hit_with_gpt::repo;
+
+fn clean() {
+    let _ = fs::remove_dir_all(".hit");
+}
+
+#[test]
+fn creates_repository_structure() {
+    clean();
+    repo::init().unwrap();
+    assert!(fs::metadata(".hit").unwrap().is_dir());
+    assert!(fs::metadata(".hit/objects").unwrap().is_dir());
+    assert!(fs::metadata(".hit/refs/heads").unwrap().is_dir());
+    assert!(fs::metadata(".hit/refs/heads/main").unwrap().is_file());
+    assert!(fs::metadata(".hit/HEAD").unwrap().is_file());
+}
+
+#[test]
+fn init_is_idempotent() {
+    clean();
+    repo::init().unwrap();
+    repo::init().unwrap();
+    assert!(fs::metadata(".hit").unwrap().is_dir());
+}


### PR DESCRIPTION
## Summary
- add clap to dependencies and set up binary name `hit`
- implement repository initialization logic
- wire up CLI entry point for `hit init`
- test repository creation and idempotency

## Testing
- `cargo test` *(fails: failed to download from `https://index.crates.io/config.json`)*

------
https://chatgpt.com/codex/tasks/task_e_68630094a6a0832ead785e03677e0025