### PR TITLE
Improve file watcher

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ serde = { version = "1", features = ["derive"] }
 sha2 = "0.10"
 bincode = "1"
 clap = { version = "4.0", features = ["derive"] }
+notify = "6"
 
 [[bin]]
 name = "hit"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
 pub mod object;
 pub mod storage;
 pub mod repo;
+pub mod watcher;

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,6 +11,7 @@ struct Cli {
 #[derive(Subcommand)]
 enum Commands {
     Init,
+    Watch,
 }
 
 fn main() {
@@ -19,6 +20,11 @@ fn main() {
         Commands::Init => {
             if let Err(e) = hit_with_gpt::repo::init() {
                 eprintln!("Error initializing repository: {}", e);
+            }
+        }
+        Commands::Watch => {
+            if let Err(e) = hit_with_gpt::watcher::watch_and_store_changes() {
+                eprintln!("Watcher error: {}", e);
             }
         }
     }

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -4,7 +4,8 @@ use std::path::{Path, PathBuf};
 
 use crate::object::{Object, Hashable};
 
-const OBJECT_DIR: &str = ".hit/objects";
+/// Directory where objects are stored.
+pub const OBJECT_DIR: &str = ".hit/objects";
 
 pub fn write_object(obj: &Object) -> std::io::Result<String> {
     fs::create_dir_all(OBJECT_DIR)?;

--- a/src/watcher.rs
+++ b/src/watcher.rs
@@ -1,0 +1,79 @@
+use std::path::Path;
+use std::sync::mpsc::channel;
+use std::time::Duration;
+
+use notify::{RecommendedWatcher, RecursiveMode, Result, Watcher, Event};
+
+use crate::object::{Blob, Object};
+use crate::storage::{write_object, OBJECT_DIR};
+
+/// File suffixes that should be ignored by the watcher.
+pub const IGNORED_SUFFIXES: &[&str] = &["~", ".swp", ".tmp"];
+
+pub fn watch_and_store_changes() -> Result<()> {
+    let (tx, rx) = channel();
+
+    let mut watcher = RecommendedWatcher::new(
+        tx,
+        notify::Config::default()
+            .with_poll_interval(Duration::from_secs(1))
+            .with_compare_contents(true),
+    )?;
+
+    watcher.watch(Path::new("."), RecursiveMode::Recursive)?;
+
+    for res in rx {
+        match res {
+            Ok(event) => {
+                if let Err(e) = handle_event(event) {
+                    eprintln!("error handling event: {}", e);
+                }
+            }
+            Err(e) => eprintln!("watch error: {:?}", e),
+        }
+    }
+    Ok(())
+}
+
+/// Handle a single notify [`Event`].
+///
+/// This function is public so it can be unit tested without running the
+/// watcher loop.
+pub fn handle_event(event: Event) -> std::io::Result<()> {
+    for path in event.paths {
+        if should_ignore(&path) {
+            continue;
+        }
+        if path.is_file() {
+            let content = std::fs::read(&path)?;
+            let blob = Blob { content };
+            let obj = Object::Blob(blob);
+            let hash = obj.hash();
+            let object_path = Path::new(OBJECT_DIR).join(&hash);
+            if object_path.exists() {
+                println!(
+                    "Detected change: {} \u2192 stored as {} (unchanged, already stored)",
+                    path.display(), hash
+                );
+            } else {
+                write_object(&obj)?;
+                println!("Detected change: {} \u2192 stored as {}", path.display(), hash);
+            }
+        }
+    }
+    Ok(())
+}
+
+fn should_ignore(path: &Path) -> bool {
+    if path.components().any(|c| c.as_os_str() == ".hit") {
+        return true;
+    }
+    if let Some(name) = path.file_name().and_then(|s| s.to_str()) {
+        for suffix in IGNORED_SUFFIXES {
+            if name.ends_with(suffix) {
+                return true;
+            }
+        }
+    }
+    false
+}


### PR DESCRIPTION
## Summary
- export `OBJECT_DIR` so other modules can check for existing objects
- skip writing duplicate blobs in `handle_event`
- expose `handle_event` for testability
- centralize ignored suffixes

## Testing
- `cargo test` *(fails: failed to fetch crates)*

------
https://chatgpt.com/codex/tasks/task_e_686305593550832ea8b643838da93237