### PR TITLE
Add SSE streaming endpoint

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,3 +73,8 @@ This project uses the following crates:
 * `hit status` – show working directory status
 * `hit log` – show commit history
 * `hit push` / `hit pull` – synchronize with central server (future)
+
+## 🌐 Server API
+
+* `POST /changes` – submit a change event
+* `GET /stream` – subscribe to real-time changes via Server-Sent Events

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1011,6 +1011,7 @@ dependencies = [
  "axum",
  "bincode",
  "clap",
+ "http-body-util",
  "httpmock",
  "hyper 1.6.0",
  "notify",
@@ -1020,6 +1021,7 @@ dependencies = [
  "serial_test",
  "sha2",
  "tokio",
+ "tokio-stream",
  "tower",
  "tracing",
  "tracing-subscriber",
@@ -2429,6 +2431,18 @@ checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
 dependencies = [
  "native-tls",
  "tokio",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eca58d7bba4a75707817a2c44174253f9236b2d5fbd055602e9d5c07c139a047"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+ "tokio-util",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,12 +15,14 @@ tracing = "0.1"
 tracing-subscriber = "0.3"
 serde_json = "1"
 reqwest = { version = "0.11", features = ["blocking", "json"] }
+tokio-stream = { version = "0.1", features = ["sync"] }
 
 [dev-dependencies]
 tower = "0.5"
 hyper = "1"
 serial_test = "2"
 httpmock = "0.6"
+http-body-util = "0.1"
 
 [[bin]]
 name = "hit"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,3 +3,4 @@ pub mod storage;
 pub mod repo;
 pub mod watcher;
 pub mod server;
+pub mod streaming;

--- a/src/server.rs
+++ b/src/server.rs
@@ -5,11 +5,13 @@ use axum::{
     routing::post,
     Json, Router,
 };
+use tokio::sync::broadcast;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use std::sync::{Arc, Mutex};
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[serde(deny_unknown_fields)]
 pub struct Change {
     pub hash: String,
     pub path: String,
@@ -21,8 +23,14 @@ pub struct ChangeStore {
     pub changes: Arc<Mutex<Vec<Change>>>,
 }
 
+#[derive(Clone)]
+pub struct AppState {
+    pub store: ChangeStore,
+    pub broadcaster: broadcast::Sender<Change>,
+}
+
 async fn change_handler(
-    State(store): State<ChangeStore>,
+    State(state): State<AppState>,
     payload: Result<Json<Change>, JsonRejection>,
 ) -> Result<impl IntoResponse, StatusCode> {
     let Json(change) = match payload {
@@ -33,22 +41,31 @@ async fn change_handler(
         }
     };
     tracing::info!("change received: {:?}", change);
-    if let Ok(mut vec) = store.changes.lock() {
-        vec.push(change);
+    if let Ok(mut vec) = state.store.changes.lock() {
+        vec.push(change.clone());
+    }
+    if let Err(e) = state.broadcaster.send(change.clone()) {
+        tracing::warn!("failed to broadcast change: {}", e);
     }
     Ok(Json(json!({"accepted": true})))
 }
 
-fn app(store: ChangeStore) -> Router {
-    Router::new()
+fn app(state: AppState) -> Router {
+    let changes = Router::new()
         .route("/changes", post(change_handler))
-        .with_state(store)
+        .with_state(state.clone());
+    let stream = crate::streaming::router(crate::streaming::Broadcaster::new(
+        state.broadcaster.clone(),
+    ));
+    changes.merge(stream)
 }
 
 pub async fn start_server() {
     tracing_subscriber::fmt::init();
     let store = ChangeStore::default();
-    let app = app(store);
+    let (tx, _) = broadcast::channel(100);
+    let state = AppState { store, broadcaster: tx };
+    let app = app(state);
     let addr = "0.0.0.0:8888";
     let listener = tokio::net::TcpListener::bind(addr).await.unwrap();
     tracing::info!("listening on http://{}", addr);
@@ -62,13 +79,17 @@ mod tests {
     use super::*;
     use axum::http::{Request, StatusCode};
     use axum::body::Body;
+    use tokio::sync::broadcast;
+    use tokio_stream::StreamExt;
     use tower::ServiceExt; // for `oneshot`
     use serde_json::{json, Value};
 
     #[tokio::test]
     async fn accepts_post() {
         let store = ChangeStore::default();
-        let app = app(store.clone());
+        let (tx, _) = broadcast::channel(8);
+        let state = AppState { store: store.clone(), broadcaster: tx };
+        let app = app(state);
 
         let change = Change {
             hash: "abc".into(),
@@ -92,7 +113,9 @@ mod tests {
     #[tokio::test]
     async fn rejects_invalid_json() {
         let store = ChangeStore::default();
-        let app = app(store.clone());
+        let (tx, _) = broadcast::channel(8);
+        let state = AppState { store: store.clone(), broadcaster: tx };
+        let app = app(state);
 
         let req = Request::builder()
             .method("POST")
@@ -108,7 +131,9 @@ mod tests {
     #[tokio::test]
     async fn rejects_missing_field() {
         let store = ChangeStore::default();
-        let app = app(store.clone());
+        let (tx, _) = broadcast::channel(8);
+        let state = AppState { store: store.clone(), broadcaster: tx };
+        let app = app(state);
 
         let body = json!({"path": "x", "timestamp": 1});
         let req = Request::builder()
@@ -125,7 +150,9 @@ mod tests {
     #[tokio::test]
     async fn stores_multiple_changes() {
         let store = ChangeStore::default();
-        let app = app(store.clone());
+        let (tx, _) = broadcast::channel(8);
+        let state = AppState { store: store.clone(), broadcaster: tx };
+        let app = app(state);
 
         for i in 0..2 {
             let change = Change {
@@ -143,5 +170,48 @@ mod tests {
             assert_eq!(resp.status(), StatusCode::OK);
         }
         assert_eq!(store.changes.lock().unwrap().len(), 2);
+    }
+
+    #[tokio::test]
+    async fn streams_changes() {
+        let store = ChangeStore::default();
+        let (tx, _) = broadcast::channel(8);
+        let state = AppState { store: store.clone(), broadcaster: tx.clone() };
+        let app = app(state);
+
+        let req = Request::builder()
+            .uri("/stream")
+            .body(Body::empty())
+            .unwrap();
+        let resp = app.clone().oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let mut stream = resp.into_body().into_data_stream();
+        let reader = tokio::spawn(async move {
+            let mut bytes = Vec::new();
+            while let Some(chunk) = stream.next().await {
+                let chunk = chunk.unwrap();
+                bytes.extend_from_slice(&chunk);
+                if bytes.ends_with(b"\n\n") {
+                    break;
+                }
+            }
+            String::from_utf8(bytes).unwrap()
+        });
+
+        let change = Change { hash: "c1".into(), path: "f".into(), timestamp: 1 };
+        let req = Request::builder()
+            .method("POST")
+            .uri("/changes")
+            .header("content-type", "application/json")
+            .body(Body::from(serde_json::to_vec(&change).unwrap()))
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let data = reader.await.unwrap();
+        assert!(data.starts_with("data: "));
+        let json_str = data.trim_start_matches("data: ").trim();
+        let streamed: Change = serde_json::from_str(json_str).unwrap();
+        assert_eq!(streamed, change);
     }
 }

--- a/src/streaming.rs
+++ b/src/streaming.rs
@@ -1,0 +1,54 @@
+use axum::{extract::State, routing::get, Router};
+use axum::response::sse::{Event, KeepAlive, Sse};
+use std::convert::Infallible;
+use std::time::Duration;
+use tokio::sync::broadcast::{Receiver, Sender};
+use tokio_stream::{wrappers::BroadcastStream, StreamExt};
+
+use crate::server::Change;
+
+#[derive(Clone)]
+pub struct Broadcaster {
+    tx: Sender<Change>,
+}
+
+impl Broadcaster {
+    pub fn new(tx: Sender<Change>) -> Self {
+        Self { tx }
+    }
+
+    pub fn subscribe(&self) -> Receiver<Change> {
+        self.tx.subscribe()
+    }
+}
+
+pub async fn sse_handler(
+    State(b): State<Broadcaster>,
+) -> Sse<impl tokio_stream::Stream<Item = Result<Event, Infallible>>> {
+    let rx = b.subscribe();
+    let stream = BroadcastStream::new(rx).filter_map(|msg| match msg {
+        Ok(change) => match serde_json::to_string(&change) {
+            Ok(d) => Some(Ok(Event::default().data(d))),
+            Err(e) => {
+                tracing::warn!("failed to serialize change: {}", e);
+                None
+            }
+        },
+        Err(e) => {
+            tracing::warn!("broadcast error: {}", e);
+            None
+        }
+    });
+    Sse::new(stream).keep_alive(
+        KeepAlive::new()
+            .interval(Duration::from_secs(15))
+            .text("keep-alive"),
+    )
+}
+
+pub fn router(broadcaster: Broadcaster) -> Router {
+    Router::new()
+        .route("/stream", get(sse_handler))
+        .with_state(broadcaster)
+}
+


### PR DESCRIPTION
## Summary
- add a broadcaster service module for SSE streaming
- integrate broadcast channel into server state and send changes to it
- expose `/stream` SSE endpoint
- document the new endpoint
- test streaming behavior

## Testing
- `cargo test -- --test-threads=1`

------
https://chatgpt.com/codex/tasks/task_e_6864430acc6c832eac4013223d38b46d