### PR TITLE
Implement SSE /events endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ The long-term vision includes an AI-powered server that decides which changes ar
 * ✅ Core object model with SHA-256 hashing and binary serialization
 * ✅ File-based object storage
 * ✅ Tests for all object and storage functionality
+* ✅ Basic real-time streaming via SSE on `/events`
 
 ## 🧱 Architecture
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -180,7 +180,7 @@ mod tests {
         let app = app(state);
 
         let req = Request::builder()
-            .uri("/stream")
+            .uri("/events")
             .body(Body::empty())
             .unwrap();
         let resp = app.clone().oneshot(req).await.unwrap();

--- a/src/streaming.rs
+++ b/src/streaming.rs
@@ -48,7 +48,7 @@ pub async fn sse_handler(
 
 pub fn router(broadcaster: Broadcaster) -> Router {
     Router::new()
-        .route("/stream", get(sse_handler))
+        .route("/events", get(sse_handler))
         .with_state(broadcaster)
 }
 


### PR DESCRIPTION
## Summary
- expose changes via `/events` SSE endpoint
- adjust unit tests to use `/events`
- document SSE capability in the README

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_686590afdf0c832e8dbe584b7d9ec731