### PR TITLE
Implement SSE sync client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -722,6 +722,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "eventsource-stream"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74fef4569247a5f429d9156b9d0a2599914385dd189c539334c625d8099d90ab"
+dependencies = [
+ "futures-core",
+ "nom",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "fastrand"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -893,6 +904,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
 
 [[package]]
+name = "futures-timer"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
+
+[[package]]
 name = "futures-util"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1011,11 +1028,13 @@ dependencies = [
  "axum",
  "bincode",
  "clap",
+ "futures-util",
  "http-body-util",
  "httpmock",
  "hyper 1.6.0",
  "notify",
  "reqwest",
+ "reqwest-eventsource",
  "serde",
  "serde_json",
  "serial_test",
@@ -1566,6 +1585,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1619,6 +1644,16 @@ name = "new_debug_unreachable"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
 
 [[package]]
 name = "notify"
@@ -1980,12 +2015,30 @@ dependencies = [
  "system-configuration",
  "tokio",
  "tokio-native-tls",
+ "tokio-util",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams",
  "web-sys",
  "winreg",
+]
+
+[[package]]
+name = "reqwest-eventsource"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f529a5ff327743addc322af460761dff5b50e0c826b9e6ac44c3195c50bb2026"
+dependencies = [
+ "eventsource-stream",
+ "futures-core",
+ "futures-timer",
+ "mime",
+ "nom",
+ "pin-project-lite",
+ "reqwest",
+ "thiserror",
 ]
 
 [[package]]
@@ -2734,6 +2787,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "wasm-streams"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,12 +10,14 @@ bincode = "1"
 clap = { version = "4.0", features = ["derive"] }
 notify = "6"
 axum = "0.7"
-tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
+tokio = { version = "1", features = ["macros", "rt-multi-thread", "signal"] }
 tracing = "0.1"
 tracing-subscriber = "0.3"
 serde_json = "1"
-reqwest = { version = "0.11", features = ["blocking", "json"] }
+reqwest = { version = "0.11", features = ["blocking", "json", "stream"] }
+reqwest-eventsource = "0.5"
 tokio-stream = { version = "0.1", features = ["sync"] }
+futures-util = "0.3"
 
 [dev-dependencies]
 tower = "0.5"

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ The long-term vision includes an AI-powered server that decides which changes ar
 
 * ✅ `hit init` – Initializes a repository with `.hit/` directory
 * ✅ `hit watch` – Watches for local file changes and stores them as `Blob`s
+* ✅ `hit sync` – Listens for server-pushed changes using SSE
 * ✅ Core object model with SHA-256 hashing and binary serialization
 * ✅ File-based object storage
 * ✅ Tests for all object and storage functionality
@@ -47,6 +48,7 @@ Server logic and AI-based syncing are still in design.
 cargo build --release
 ./target/release/hit init
 ./target/release/hit watch
+./target/release/hit sync
 ```
 
 ## 📂 Code Structure
@@ -55,6 +57,7 @@ cargo build --release
 * `src/storage.rs` – Object read/write logic
 * `src/repo.rs` – Repository setup (`hit init`)
 * `src/watcher.rs` – Filesystem watcher (`hit watch`)
+* `src/sync.rs` – SSE client (`hit sync`)
 * `main.rs` – CLI commands (`clap`)
 
 ## 🛣 Roadmap

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,3 +4,4 @@ pub mod repo;
 pub mod watcher;
 pub mod server;
 pub mod streaming;
+pub mod sync;

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,6 +13,7 @@ enum Commands {
     Init,
     Watch,
     Serve,
+    Sync,
 }
 
 #[tokio::main]
@@ -31,6 +32,9 @@ async fn main() {
         }
         Commands::Serve => {
             hit_with_gpt::server::start_server().await;
+        }
+        Commands::Sync => {
+            hit_with_gpt::sync::sync_from_server().await;
         }
     }
 }

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -1,0 +1,70 @@
+use std::env;
+use std::time::Duration;
+
+use reqwest::Client;
+use reqwest_eventsource::{Event, EventSource};
+use futures_util::StreamExt;
+use tokio::time::sleep;
+
+use crate::server::Change;
+
+/// Connect to the server and listen for change events via SSE.
+///
+/// The server URL is taken from the `HIT_SERVER_URL` environment variable,
+/// defaulting to `http://localhost:8888` if unset.
+///
+/// On each incoming event a log line is printed. The function retries with
+/// exponential backoff if the connection drops and exits cleanly on `Ctrl+C`.
+pub async fn sync_from_server() {
+    let base = env::var("HIT_SERVER_URL").unwrap_or_else(|_| "http://localhost:8888".into());
+    let url = format!("{}/events", base.trim_end_matches('/'));
+
+    let client = Client::new();
+    let mut backoff = 1u64;
+
+    loop {
+        eprintln!("Connecting to {}", url);
+        let request = client.get(&url);
+        match EventSource::new(request) {
+            Ok(mut source) => {
+                let mut shutdown = Box::pin(tokio::signal::ctrl_c());
+                loop {
+                    tokio::select! {
+                        _ = &mut shutdown => {
+                            let _ = source.close();
+                            return;
+                        }
+                        message = source.next() => match message {
+                            Some(Ok(Event::Open)) => {
+                                backoff = 1;
+                                eprintln!("Connected");
+                            }
+                            Some(Ok(Event::Message(msg))) => {
+                                match serde_json::from_str::<Change>(&msg.data) {
+                                    Ok(change) => {
+                                        println!("Received change: {} {}", change.hash, change.path);
+                                    }
+                                    Err(e) => eprintln!("failed to parse event: {}", e),
+                                }
+                            }
+                            Some(Err(e)) => {
+                                eprintln!("stream error: {}", e);
+                                break;
+                            }
+                            None => {
+                                eprintln!("server closed connection");
+                                break;
+                            }
+                        }
+                    }
+                }
+            }
+            Err(e) => eprintln!("failed to connect: {}", e),
+        }
+
+        let delay = backoff.min(30);
+        eprintln!("reconnecting in {}s", delay);
+        sleep(Duration::from_secs(delay)).await;
+        backoff = (backoff * 2).min(30);
+    }
+}

--- a/tests/sync.rs
+++ b/tests/sync.rs
@@ -1,0 +1,41 @@
+use std::time::Duration;
+
+use tokio::sync::broadcast;
+use tokio::net::TcpListener;
+use tokio::time::sleep;
+use serde_json;
+use reqwest_eventsource::{EventSource, Event};
+use futures_util::StreamExt;
+
+use hit_with_gpt::server::Change;
+use hit_with_gpt::streaming::{self, Broadcaster};
+
+#[tokio::test]
+async fn parses_sse_event() {
+    let (tx, _) = broadcast::channel(8);
+    let router = streaming::router(Broadcaster::new(tx.clone()));
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        axum::serve(listener, router).await.unwrap();
+    });
+
+    // send a change after clients can connect
+    tokio::spawn(async move {
+        sleep(Duration::from_millis(100)).await;
+        tx.send(Change { hash: "abcd".into(), path: "foo.txt".into(), timestamp: 1 }).unwrap();
+    });
+
+    let url = format!("http://{}/events", addr);
+    let client = reqwest::Client::new();
+    let mut es = EventSource::new(client.get(&url)).unwrap();
+    // first event should be Open
+    matches!(es.next().await.unwrap().unwrap(), Event::Open);
+    if let Event::Message(msg) = es.next().await.unwrap().unwrap() {
+        let change: Change = serde_json::from_str(&msg.data).unwrap();
+        assert_eq!(change.hash, "abcd");
+        assert_eq!(change.path, "foo.txt");
+    } else {
+        panic!("expected message event");
+    }
+}


### PR DESCRIPTION
## Summary
- add `reqwest-eventsource` SSE client dependency
- implement `sync_from_server` with reconnection, Ctrl+C handling, and event logging
- expose new `Sync` CLI command
- test SSE parsing with an in-process `axum` server
- document `hit sync` in README

## Testing
- `cargo check`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_686593c4c46c832ea2e501b7e6065c8d