### PR TITLE
Add tracing logs and basic client sync

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -18,16 +18,22 @@ enum Commands {
 
 #[tokio::main]
 async fn main() {
+    tracing_subscriber::fmt()
+        .with_max_level(tracing::Level::INFO)
+        .with_target(true)
+        .pretty()
+        .init();
+
     let cli = Cli::parse();
     match cli.command {
         Commands::Init => {
             if let Err(e) = hit_with_gpt::repo::init() {
-                eprintln!("Error initializing repository: {}", e);
+                tracing::error!(%e, "Error initializing repository");
             }
         }
         Commands::Watch => {
             if let Err(e) = hit_with_gpt::watcher::watch_and_store_changes() {
-                eprintln!("Watcher error: {}", e);
+                tracing::error!(%e, "Watcher error");
             }
         }
         Commands::Serve => {

--- a/src/repo.rs
+++ b/src/repo.rs
@@ -1,6 +1,7 @@
 use std::fs::{self, File};
 use std::io::Write;
 use std::path::PathBuf;
+use tracing::info;
 
 /// Initialize a new hit repository in the current directory.
 ///
@@ -11,9 +12,9 @@ pub fn init() -> std::io::Result<PathBuf> {
     let hit_dir = cwd.join(".hit");
 
     if hit_dir.exists() {
-        println!("Reinitialized existing hit repository in {}", hit_dir.display());
+        info!(path = %hit_dir.display(), "Reinitialized existing hit repository");
     } else {
-        println!("Initialized empty hit repository in {}", hit_dir.display());
+        info!(path = %hit_dir.display(), "Initialized empty hit repository");
     }
 
     fs::create_dir_all(hit_dir.join("objects"))?;

--- a/src/server.rs
+++ b/src/server.rs
@@ -61,7 +61,6 @@ fn app(state: AppState) -> Router {
 }
 
 pub async fn start_server() {
-    tracing_subscriber::fmt::init();
     let store = ChangeStore::default();
     let (tx, _) = broadcast::channel(100);
     let state = AppState { store, broadcaster: tx };


### PR DESCRIPTION
## Summary
- add tracing subscriber initialization and log errors in main
- convert repo init and watcher to structured logging
- parse sync events and log them with tracing
- remove subscriber duplication in server

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_686add4d69f4832ea48f9811ec99ccdd