### PR TITLE
Add basic commit tracking

### DIFF
--- a/src/commit.rs
+++ b/src/commit.rs
@@ -1,0 +1,48 @@
+use serde::{Deserialize, Serialize};
+use std::sync::{Arc, Mutex};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use crate::server::Change;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(deny_unknown_fields)]
+pub struct Commit {
+    pub id: u64,
+    pub changes: Vec<Change>,
+    pub timestamp: u64,
+}
+
+#[derive(Clone, Default)]
+pub struct CommitStore {
+    pub commits: Arc<Mutex<Vec<Commit>>>,
+}
+
+impl CommitStore {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn add_commit(&self, change: Change) -> Commit {
+        let mut commits = self.commits.lock().unwrap();
+        let id = commits.last().map(|c| c.id + 1).unwrap_or(1);
+        let timestamp = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+        let commit = Commit {
+            id,
+            changes: vec![change],
+            timestamp,
+        };
+        commits.push(commit.clone());
+        commit
+    }
+
+    pub fn all(&self) -> Vec<Commit> {
+        self.commits.lock().unwrap().clone()
+    }
+
+    pub fn latest(&self) -> Option<Commit> {
+        self.commits.lock().unwrap().last().cloned()
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,3 +5,4 @@ pub mod watcher;
 pub mod server;
 pub mod streaming;
 pub mod sync;
+pub mod commit;

--- a/src/streaming.rs
+++ b/src/streaming.rs
@@ -1,23 +1,23 @@
-use axum::{extract::State, routing::get, Router};
 use axum::response::sse::{Event, KeepAlive, Sse};
+use axum::{Router, extract::State, routing::get};
 use std::convert::Infallible;
 use std::time::Duration;
 use tokio::sync::broadcast::{Receiver, Sender};
-use tokio_stream::{wrappers::BroadcastStream, StreamExt};
+use tokio_stream::{StreamExt, wrappers::BroadcastStream};
 
-use crate::server::Change;
+use crate::server::ChangeEvent;
 
 #[derive(Clone)]
 pub struct Broadcaster {
-    tx: Sender<Change>,
+    tx: Sender<ChangeEvent>,
 }
 
 impl Broadcaster {
-    pub fn new(tx: Sender<Change>) -> Self {
+    pub fn new(tx: Sender<ChangeEvent>) -> Self {
         Self { tx }
     }
 
-    pub fn subscribe(&self) -> Receiver<Change> {
+    pub fn subscribe(&self) -> Receiver<ChangeEvent> {
         self.tx.subscribe()
     }
 }
@@ -51,4 +51,3 @@ pub fn router(broadcaster: Broadcaster) -> Router {
         .route("/events", get(sse_handler))
         .with_state(broadcaster)
 }
-


### PR DESCRIPTION
### **User description**
## Summary
- introduce `Commit` and `CommitStore`
- track commits on the server and expose `/commits` and `/commits/latest`
- broadcast commit IDs over SSE
- track commit IDs in the sync client
- update tests for new commit functionality

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68757d52e9ac832eb9ab1ebc199de94c


___

### **PR Type**
Enhancement


___

### **Description**
- Add commit tracking system with `Commit` and `CommitStore`

- Expose `/commits` and `/commits/latest` API endpoints

- Broadcast commit IDs through SSE events

- Track commit progression in sync client


___

### **Changes diagram**

```mermaid
flowchart LR
  A["Change received"] --> B["Create Commit"]
  B --> C["Store in CommitStore"]
  B --> D["Broadcast ChangeEvent with commit_id"]
  D --> E["SSE clients receive commit info"]
  C --> F["Expose via /commits API"]
  C --> G["Expose via /commits/latest API"]
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>commit.rs</strong><dd><code>Create commit data structures and storage</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/commit.rs

<li>Define <code>Commit</code> struct with id, changes, and timestamp<br> <li> Implement <code>CommitStore</code> with thread-safe storage<br> <li> Add methods for adding commits and retrieving all/latest


</details>


  </td>
  <td><a href="https://github.com/neriyabl/hit-with-gpt/pull/15/files#diff-bb4e08eea4e3dc7224dbdbf3a859fe20f3256962398f01fa518fefa70198c2fc">+48/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>server.rs</strong><dd><code>Integrate commit system into server with new endpoints</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/server.rs

<li>Add <code>CommitStore</code> to <code>AppState</code> and create commits on changes<br> <li> Replace <code>Change</code> broadcasts with <code>ChangeEvent</code> containing commit_id<br> <li> Add <code>/commits</code> and <code>/commits/latest</code> API endpoints<br> <li> Update all tests to use new commit system


</details>


  </td>
  <td><a href="https://github.com/neriyabl/hit-with-gpt/pull/15/files#diff-48d27698cc708c7efe770fd897e4885efaa0a15cae30d54936068603ba03bbd9">+191/-20</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>streaming.rs</strong><dd><code>Update SSE streaming for commit events</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/streaming.rs

<li>Change broadcaster type from <code>Change</code> to <code>ChangeEvent</code><br> <li> Update SSE streaming to include commit information


</details>


  </td>
  <td><a href="https://github.com/neriyabl/hit-with-gpt/pull/15/files#diff-0d84543a38bfde5dd1d90d522a8554ff7f2709f9f729779f7d15f15063193b8e">+6/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>sync.rs</strong><dd><code>Add commit tracking to sync client</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/sync.rs

<li>Track <code>last_commit</code> ID in sync client<br> <li> Parse <code>ChangeEvent</code> instead of <code>Change</code> from SSE<br> <li> Log commit progression during sync


</details>


  </td>
  <td><a href="https://github.com/neriyabl/hit-with-gpt/pull/15/files#diff-44e47ea9be0c53791e7aed4ba12a105bc663405ad3dec0008bc90c85505e1e11">+9/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>lib.rs</strong><dd><code>Export commit module</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/lib.rs

- Add `commit` module to public API


</details>


  </td>
  <td><a href="https://github.com/neriyabl/hit-with-gpt/pull/15/files#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>sync.rs</strong><dd><code>Update sync tests for commit events</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/sync.rs

<li>Update test to send <code>ChangeEvent</code> instead of <code>Change</code><br> <li> Verify commit_id is properly received in SSE events


</details>


  </td>
  <td><a href="https://github.com/neriyabl/hit-with-gpt/pull/15/files#diff-be92e762c2bf08917b5e6e184266b33c7efd6b817fa44f5bb0bed3947e3689dd">+12/-8</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>