### PR TITLE
Implement append-only commit log

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -448,6 +448,8 @@ version = "1.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d487aa071b5f64da6f19a3e848e3578944b726ee5a4854b82172f02aa876bfdc"
 dependencies = [
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -1044,6 +1046,7 @@ dependencies = [
  "tower",
  "tracing",
  "tracing-subscriber",
+ "zstd",
 ]
 
 [[package]]
@@ -1413,6 +1416,16 @@ name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+
+[[package]]
+name = "jobserver"
+version = "0.1.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38f262f097c174adebe41eb73d66ae9c06b2844fb0da69969647bbddd9b0538a"
+dependencies = [
+ "getrandom 0.3.3",
+ "libc",
+]
 
 [[package]]
 name = "js-sys"
@@ -3092,4 +3105,32 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.15+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb81183ddd97d0c74cedf1d50d85c8d08c1b8b68ee863bdee9e706eedba1a237"
+dependencies = [
+ "cc",
+ "pkg-config",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ reqwest = { version = "0.11", features = ["blocking", "json", "stream"] }
 reqwest-eventsource = "0.5"
 tokio-stream = { version = "0.1", features = ["sync"] }
 futures-util = "0.3"
+zstd = "0.13"
 
 [dev-dependencies]
 tower = "0.5"

--- a/src/commit_log.rs
+++ b/src/commit_log.rs
@@ -17,7 +17,6 @@ impl CommitLog {
         let file = OpenOptions::new()
             .create(true)
             .append(true)
-            .read(true)
             .open(&path)?;
         Ok(Self { path, file })
     }

--- a/src/commit_log.rs
+++ b/src/commit_log.rs
@@ -1,0 +1,99 @@
+use std::fs::{File, OpenOptions};
+use std::io::{self, Read, Write};
+use std::path::{Path, PathBuf};
+
+use crate::commit::Commit;
+
+/// Append-only commit log stored on disk.
+pub struct CommitLog {
+    path: PathBuf,
+    file: File,
+}
+
+impl CommitLog {
+    /// Open the commit log for appending. The file is created if it doesn't exist.
+    pub fn open(path: impl AsRef<Path>) -> io::Result<Self> {
+        let path = path.as_ref().to_owned();
+        let file = OpenOptions::new()
+            .create(true)
+            .append(true)
+            .read(true)
+            .open(&path)?;
+        Ok(Self { path, file })
+    }
+
+    /// Append a commit to the log and flush to disk.
+    pub fn append(&mut self, commit: &Commit) -> io::Result<()> {
+        let data = bincode::serialize(commit).map_err(to_io_err)?;
+        let compressed = zstd::stream::encode_all(&data[..], 0)?;
+        let len = compressed.len() as u32;
+        self.file.write_all(&len.to_le_bytes())?;
+        self.file.write_all(&compressed)?;
+        self.file.sync_data()?;
+        Ok(())
+    }
+
+    /// Load all commits from the given path.
+    pub fn load(path: impl AsRef<Path>) -> io::Result<Vec<Commit>> {
+        let path = path.as_ref();
+        let mut file = match File::open(path) {
+            Ok(f) => f,
+            Err(e) if e.kind() == io::ErrorKind::NotFound => return Ok(Vec::new()),
+            Err(e) => return Err(e),
+        };
+        let mut commits = Vec::new();
+        loop {
+            let mut len_buf = [0u8; 4];
+            if let Err(e) = file.read_exact(&mut len_buf) {
+                if e.kind() == io::ErrorKind::UnexpectedEof {
+                    break;
+                }
+                return Err(e);
+            }
+            let len = u32::from_le_bytes(len_buf) as usize;
+            let mut data = vec![0u8; len];
+            file.read_exact(&mut data)?;
+            let decompressed = zstd::stream::decode_all(&data[..])?;
+            let commit: Commit = bincode::deserialize(&decompressed).map_err(to_io_err)?;
+            commits.push(commit);
+        }
+        Ok(commits)
+    }
+
+    /// Path backing the commit log.
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+fn to_io_err<E: std::fmt::Display>(e: E) -> io::Error {
+    io::Error::new(io::ErrorKind::Other, format!("{}", e))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::server::Change;
+    use crate::commit::Commit;
+    use serial_test::serial;
+
+    fn log_path() -> &'static str { "test_commits.log" }
+
+    fn clean() { let _ = std::fs::remove_file(log_path()); }
+
+    #[test]
+    #[serial]
+    fn write_and_reload() {
+        clean();
+        let mut log = CommitLog::open(log_path()).unwrap();
+        let commit1 = Commit { id: 1, changes: vec![Change { hash: "h1".into(), path: "p".into(), timestamp: 1 }], timestamp: 1 };
+        let commit2 = Commit { id: 2, changes: vec![Change { hash: "h2".into(), path: "p".into(), timestamp: 2 }], timestamp: 2 };
+        log.append(&commit1).unwrap();
+        log.append(&commit2).unwrap();
+        drop(log);
+
+        let loaded = CommitLog::load(log_path()).unwrap();
+        assert_eq!(loaded, vec![commit1, commit2]);
+        clean();
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,3 +6,4 @@ pub mod server;
 pub mod streaming;
 pub mod sync;
 pub mod commit;
+pub mod commit_log;

--- a/src/server.rs
+++ b/src/server.rs
@@ -95,8 +95,9 @@ fn app(state: AppState) -> Router {
 }
 
 pub async fn start_server() {
-    std::fs::create_dir_all(".hit").unwrap();
-    let commits = CommitStore::with_log(".hit/commits.log").unwrap();
+    std::fs::create_dir_all(".hit").expect("Failed to create .hit directory");
+    let commits =
+        CommitStore::with_log(".hit/commits.log").expect("Failed to initialize commit log");
     let (tx, _) = broadcast::channel(100);
     let state = AppState {
         commits,

--- a/src/server.rs
+++ b/src/server.rs
@@ -95,7 +95,8 @@ fn app(state: AppState) -> Router {
 }
 
 pub async fn start_server() {
-    let commits = CommitStore::default();
+    std::fs::create_dir_all(".hit").unwrap();
+    let commits = CommitStore::with_log(".hit/commits.log").unwrap();
     let (tx, _) = broadcast::channel(100);
     let state = AppState {
         commits,


### PR DESCRIPTION
### **User description**
## Summary
- add a zstd-compressed append only commit log
- use the log in `CommitStore` and load it for the server
- test commit log round trips

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_68794626060c832eaa101aa9bf4189d2


___

### **PR Type**
Enhancement


___

### **Description**
- Add zstd-compressed append-only commit log for persistence

- Integrate commit log with `CommitStore` for automatic persistence

- Load existing commits from log on server startup

- Add comprehensive tests for commit log round-trip functionality


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["CommitStore"] --> B["CommitLog"]
  B --> C["Disk Storage"]
  D["Server Startup"] --> E["Load Commits"]
  E --> A
  A --> F["Add Commit"]
  F --> B
  B --> G["Append & Compress"]
  G --> C
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>commit_log.rs</strong><dd><code>Add compressed append-only commit log implementation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/commit_log.rs

<ul><li>Create new <code>CommitLog</code> struct for append-only persistence<br> <li> Implement zstd compression for commit serialization<br> <li> Add <code>open()</code>, <code>append()</code>, and <code>load()</code> methods<br> <li> Include comprehensive round-trip tests</ul>


</details>


  </td>
  <td><a href="https://github.com/neriyabl/hit-with-gpt/pull/16/files#diff-9479f71f48e7332b4374c5aef749f4421faafeb53344b1a9068e404f7fc855cb">+99/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>commit.rs</strong><dd><code>Integrate commit log with CommitStore</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/commit.rs

<ul><li>Add optional <code>CommitLog</code> field to <code>CommitStore</code><br> <li> Implement <code>with_log()</code> constructor for persistent storage<br> <li> Modify <code>add_commit()</code> to append to log automatically<br> <li> Update <code>Default</code> implementation to handle new field</ul>


</details>


  </td>
  <td><a href="https://github.com/neriyabl/hit-with-gpt/pull/16/files#diff-bb4e08eea4e3dc7224dbdbf3a859fe20f3256962398f01fa518fefa70198c2fc">+28/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>server.rs</strong><dd><code>Enable persistent commit storage in server</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/server.rs

<ul><li>Create <code>.hit</code> directory for storage<br> <li> Initialize <code>CommitStore</code> with persistent log file<br> <li> Replace default store with log-backed implementation</ul>


</details>


  </td>
  <td><a href="https://github.com/neriyabl/hit-with-gpt/pull/16/files#diff-48d27698cc708c7efe770fd897e4885efaa0a15cae30d54936068603ba03bbd9">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>lib.rs</strong><dd><code>Export commit log module</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/lib.rs

- Add `commit_log` module to public API


</details>


  </td>
  <td><a href="https://github.com/neriyabl/hit-with-gpt/pull/16/files#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Cargo.toml</strong><dd><code>Add zstd compression dependency</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Cargo.toml

- Add `zstd` dependency for compression support


</details>


  </td>
  <td><a href="https://github.com/neriyabl/hit-with-gpt/pull/16/files#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

