### PR TITLE
Fix sync and deduplication issues

### DIFF
--- a/tests/deduplication_test.rs
+++ b/tests/deduplication_test.rs
@@ -1,0 +1,83 @@
+use hit_with_gpt::commit::CommitStore;
+use hit_with_gpt::server::Change;
+use serial_test::serial;
+
+#[test]
+#[serial]
+fn test_duplicate_changes_are_deduplicated() {
+    let store = CommitStore::default();
+    
+    let change = Change {
+        hash: "abc123".to_string(),
+        path: "test.txt".to_string(),
+        timestamp: 1000,
+    };
+    
+    // Add the same change twice
+    let commit1 = store.add_commit(change.clone()).expect("first commit should succeed");
+    let commit2 = store.add_commit(change.clone()).expect("second commit should succeed");
+    
+    // Should return the same commit (no new commit created)
+    assert_eq!(commit1.id, commit2.id, "duplicate changes should return the same commit");
+    
+    // Verify only one commit exists
+    let all_commits = store.all().expect("should get all commits");
+    assert_eq!(all_commits.len(), 1, "should only have one commit for duplicate changes");
+}
+
+#[test]
+#[serial]
+fn test_different_changes_create_separate_commits() {
+    let store = CommitStore::default();
+    
+    let change1 = Change {
+        hash: "abc123".to_string(),
+        path: "test.txt".to_string(),
+        timestamp: 1000,
+    };
+    
+    let change2 = Change {
+        hash: "def456".to_string(), // Different hash
+        path: "test.txt".to_string(),
+        timestamp: 1001,
+    };
+    
+    let commit1 = store.add_commit(change1).expect("first commit should succeed");
+    let commit2 = store.add_commit(change2).expect("second commit should succeed");
+    
+    // Should create different commits
+    assert_ne!(commit1.id, commit2.id, "different changes should create separate commits");
+    assert_eq!(commit2.id, commit1.id + 1, "second commit should have incremented ID");
+    
+    // Verify two commits exist
+    let all_commits = store.all().expect("should get all commits");
+    assert_eq!(all_commits.len(), 2, "should have two commits for different changes");
+}
+
+#[test]
+#[serial]
+fn test_same_hash_different_path_creates_new_commit() {
+    let store = CommitStore::default();
+    
+    let change1 = Change {
+        hash: "abc123".to_string(),
+        path: "test1.txt".to_string(),
+        timestamp: 1000,
+    };
+    
+    let change2 = Change {
+        hash: "abc123".to_string(), // Same hash
+        path: "test2.txt".to_string(), // Different path
+        timestamp: 1001,
+    };
+    
+    let commit1 = store.add_commit(change1).expect("first commit should succeed");
+    let commit2 = store.add_commit(change2).expect("second commit should succeed");
+    
+    // Should create different commits (same content, different files)
+    assert_ne!(commit1.id, commit2.id, "same hash different path should create separate commits");
+    
+    // Verify two commits exist
+    let all_commits = store.all().expect("should get all commits");
+    assert_eq!(all_commits.len(), 2, "should have two commits for same hash different paths");
+}

--- a/tests/watcher_fix_test.rs
+++ b/tests/watcher_fix_test.rs
@@ -1,0 +1,54 @@
+use std::fs;
+use std::path::Path;
+
+use hit_with_gpt::watcher::handle_event;
+use hit_with_gpt::object::{Blob, Object, Hashable};
+use hit_with_gpt::storage::write_object;
+use notify::{Event, EventKind};
+use serial_test::serial;
+
+fn clean() {
+    let _ = fs::remove_dir_all(".hit");
+}
+
+#[test]
+#[serial]
+fn test_handles_existing_objects_correctly() {
+    clean();
+    
+    // Create a blob and store it first
+    let content = b"hello world".to_vec();
+    let blob = Blob { content: content.clone() };
+    let obj = Object::Blob(blob);
+    let hash = obj.hash();
+    
+    // Pre-store the object
+    write_object(&obj).expect("failed to write object");
+    
+    // Verify object exists
+    let object_path = Path::new(".hit/objects").join(&hash);
+    assert!(object_path.exists(), "object should exist before test");
+    
+    // Create a test file with the same content
+    let test_file = Path::new("test_existing.txt");
+    fs::write(test_file, &content).expect("failed to write test file");
+    
+    // Create a mock event for the file
+    let event = Event {
+        kind: EventKind::Modify(notify::event::ModifyKind::Data(notify::event::DataChange::Content)),
+        paths: vec![test_file.to_path_buf()],
+        attrs: Default::default(),
+    };
+    
+    // Handle the event - this should succeed even though object already exists
+    let result = handle_event(event);
+    
+    // Clean up
+    fs::remove_file(test_file).ok();
+    
+    // The key test: handle_event should succeed even for existing objects
+    assert!(result.is_ok(), "handle_event should succeed for existing objects");
+    
+    // Verify the object still exists (wasn't corrupted)
+    assert!(object_path.exists(), "object should still exist after handling event");
+}


### PR DESCRIPTION
### **User description**
- Fix watcher to always send change notifications to server, even for existing objects
- Add server-side deduplication to prevent duplicate commits for same hash+path
- Filter watcher events to only process relevant Modify(Data) events
- Add smart broadcasting to avoid unnecessary client notifications
- Add comprehensive tests for deduplication logic and existing object handling

Fixes:
- Sync clients not receiving changes when files revert to previous states
- Excessive duplicate events and commits from filesystem watcher
- Unnecessary network traffic from duplicate change notifications


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Fix server-side deduplication preventing duplicate commits

- Always send change notifications for existing objects

- Filter watcher events to process only data modifications

- Add smart broadcasting to avoid unnecessary notifications


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["File Change"] --> B["Watcher Filter"]
  B --> C["Handle Event"]
  C --> D["Send to Server"]
  D --> E["Deduplication Check"]
  E --> F["Create/Return Commit"]
  F --> G["Smart Broadcasting"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>commit.rs</strong><dd><code>Add server-side commit deduplication logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/commit.rs

<ul><li>Add deduplication logic to check for existing changes with same <br>hash+path<br> <li> Return existing commit instead of creating duplicate<br> <li> Add tracing for skipped duplicate changes</ul>


</details>


  </td>
  <td><a href="https://github.com/neriyabl/hit-with-gpt/pull/19/files#diff-bb4e08eea4e3dc7224dbdbf3a859fe20f3256962398f01fa518fefa70198c2fc">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>watcher.rs</strong><dd><code>Fix watcher to handle existing objects properly</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/watcher.rs

<ul><li>Filter events to only process Modify(Data) events<br> <li> Always send change notifications regardless of local storage<br> <li> Separate object storage from change notification logic</ul>


</details>


  </td>
  <td><a href="https://github.com/neriyabl/hit-with-gpt/pull/19/files#diff-1da27f8f1e640e15a97d5abc50f3b1466b6a5ab525f58527da4ad8efaa5e5e19">+16/-11</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>server.rs</strong><dd><code>Implement smart broadcasting for change events</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/server.rs

<ul><li>Add smart broadcasting to avoid duplicate notifications<br> <li> Check if commit is new before broadcasting<br> <li> Add logging for duplicate change handling</ul>


</details>


  </td>
  <td><a href="https://github.com/neriyabl/hit-with-gpt/pull/19/files#diff-48d27698cc708c7efe770fd897e4885efaa0a15cae30d54936068603ba03bbd9">+18/-6</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>deduplication_test.rs</strong><dd><code>Add comprehensive deduplication test coverage</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/deduplication_test.rs

<ul><li>Test duplicate changes return same commit<br> <li> Test different changes create separate commits<br> <li> Test same hash different path behavior</ul>


</details>


  </td>
  <td><a href="https://github.com/neriyabl/hit-with-gpt/pull/19/files#diff-b9feedef2c9a6cc015684d2d5837028c744a251d94b1a1c944b83540bd707cce">+83/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>watcher_fix_test.rs</strong><dd><code>Add tests for existing object handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/watcher_fix_test.rs

<ul><li>Test handling events for pre-existing objects<br> <li> Verify watcher doesn't fail on existing files<br> <li> Test object integrity after event handling</ul>


</details>


  </td>
  <td><a href="https://github.com/neriyabl/hit-with-gpt/pull/19/files#diff-bc1ac1b97ca969b49ef054e083d15db0c2a72d82e397dbe36eff6027843d6d09">+54/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

